### PR TITLE
Use base64 encoding for exec() binary safe output when deriving share…

### DIFF
--- a/src/ApplePay/Decoding/OpenSSL/OpenSslService.php
+++ b/src/ApplePay/Decoding/OpenSSL/OpenSslService.php
@@ -99,7 +99,8 @@ class OpenSslService
      * @throws \RuntimeException
      */
     public function deriveKey($privateKeyFilePath, $publicKeyFilePath) {
-        $command = 'openssl pkeyutl -derive -inkey '.$privateKeyFilePath.' -peerkey '.$publicKeyFilePath;
+        // note: use base64 encoding for binary safe output
+        $command = 'openssl pkeyutl -derive -inkey '.$privateKeyFilePath.' -peerkey '.$publicKeyFilePath . ' | base64';
 
         $execStatus = null;
         $execOutput = null;
@@ -109,7 +110,7 @@ class OpenSslService
             throw new \RuntimeException("Can't derive secret");
         }
 
-        return $execOutput[0];
+        return base64_decode($execOutput[0]);
     }
 
 }

--- a/src/ApplePay/Decoding/OpenSSL/OpenSslService.php
+++ b/src/ApplePay/Decoding/OpenSSL/OpenSslService.php
@@ -100,7 +100,7 @@ class OpenSslService
      */
     public function deriveKey($privateKeyFilePath, $publicKeyFilePath) {
         // note: use base64 encoding for binary safe output
-        $command = 'openssl pkeyutl -derive -inkey '.$privateKeyFilePath.' -peerkey '.$publicKeyFilePath . ' | base64 -w 0';
+        $command = 'openssl pkeyutl -derive -inkey '.$privateKeyFilePath.' -peerkey '.$publicKeyFilePath . ' | base64 | tr -d \\\\n';
 
         $execStatus = null;
         $execOutput = null;

--- a/src/ApplePay/Decoding/OpenSSL/OpenSslService.php
+++ b/src/ApplePay/Decoding/OpenSSL/OpenSslService.php
@@ -100,7 +100,7 @@ class OpenSslService
      */
     public function deriveKey($privateKeyFilePath, $publicKeyFilePath) {
         // note: use base64 encoding for binary safe output
-        $command = 'openssl pkeyutl -derive -inkey '.$privateKeyFilePath.' -peerkey '.$publicKeyFilePath . ' | openssl base64';
+        $command = 'openssl pkeyutl -derive -inkey '.$privateKeyFilePath.' -peerkey '.$publicKeyFilePath . ' | base64 -w 0';
 
         $execStatus = null;
         $execOutput = null;
@@ -108,6 +108,10 @@ class OpenSslService
 
         if ($execStatus !== 0) {
             throw new \RuntimeException("Can't derive secret");
+        }
+
+        if (empty($execOutput)) {
+            throw new \RuntimeException("Unexpected empty result");
         }
 
         return base64_decode($execOutput[0]);

--- a/src/ApplePay/Decoding/OpenSSL/OpenSslService.php
+++ b/src/ApplePay/Decoding/OpenSSL/OpenSslService.php
@@ -100,7 +100,7 @@ class OpenSslService
      */
     public function deriveKey($privateKeyFilePath, $publicKeyFilePath) {
         // note: use base64 encoding for binary safe output
-        $command = 'openssl pkeyutl -derive -inkey '.$privateKeyFilePath.' -peerkey '.$publicKeyFilePath . ' | base64';
+        $command = 'openssl pkeyutl -derive -inkey '.$privateKeyFilePath.' -peerkey '.$publicKeyFilePath . ' | openssl base64';
 
         $execStatus = null;
         $execOutput = null;


### PR DESCRIPTION
…d key (may contain CR/LF, etc)