### PR TITLE
Use hash_equals instead of strict equality check

### DIFF
--- a/src/ApplePay/Decoding/SignatureVerifier/EccSignatureVerifier.php
+++ b/src/ApplePay/Decoding/SignatureVerifier/EccSignatureVerifier.php
@@ -34,10 +34,11 @@ class EccSignatureVerifier implements SignatureVerifierInterface
     public function verify(array $paymentData)
     {
         $signedData = base64_decode($paymentData['header']['ephemeralPublicKey']) . base64_decode($paymentData['data']) . hex2bin($paymentData['header']['transactionId']);
+        $signedHash = hash('sha256', $signedData, true);
 
         $this->asn1Wrapper->loadFromString(base64_decode($paymentData['signature']));
 
-        if (hash('sha256', $signedData, true) !== $this->asn1Wrapper->getDigestMessage()) {
+        if (!hash_equals($signedHash, $this->asn1Wrapper->getDigestMessage())) {
             throw new SignatureException('Invalid digest');
         }
 


### PR DESCRIPTION
Use `hash_equals()` which performs a time insensitive test.

I guess it's not super important but it is still nice. 