### PR TITLE
Switch to proc_open

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "require": {
         "ext-openssl": "*",
         "phpseclib/phpseclib": "^2.0",
-        "spomky-labs/php-aes-gcm": "^1.2"
+        "spomky-labs/php-aes-gcm": "^1.2",
+        "symfony/process": "^3.4|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7"

--- a/src/ApplePay/Decoding/OpenSSL/OpenSslService.php
+++ b/src/ApplePay/Decoding/OpenSSL/OpenSslService.php
@@ -59,7 +59,7 @@ class OpenSslService
         try {
             $commandOutput = $this->runCommand($getCertificatesCommand);
         } catch (ProcessFailedException $e) {
-            throw new \RuntimeException("Cant't get certificates", 0, $e);
+            throw new \RuntimeException("Can't get certificates", 0, $e);
         }
 
         return rtrim($commandOutput);
@@ -103,7 +103,7 @@ class OpenSslService
     }
 
     /**
-     * @param string|array $command
+     * @param string $command
      * @return string
      * @throws ProcessFailedException
      */

--- a/src/ApplePay/Decoding/OpenSSL/OpenSslService.php
+++ b/src/ApplePay/Decoding/OpenSSL/OpenSslService.php
@@ -3,6 +3,7 @@
 namespace PayU\ApplePay\Decoding\OpenSSL;
 
 use PayU\ApplePay\Decoding\SignatureVerifier\Exception\SignatureException;
+use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
 class OpenSslService
@@ -19,7 +20,7 @@ class OpenSslService
 
         try {
             $this->runCommand($verifyCertificateCommand);
-        } catch (\Exception $e) {
+        } catch (ProcessFailedException $e) {
             throw new \RuntimeException("Can't validate certificate chain", 0, $e);
         }
 
@@ -57,7 +58,7 @@ class OpenSslService
 
         try {
             $commandOutput = $this->runCommand($getCertificatesCommand);
-        } catch (\Exception $e) {
+        } catch (ProcessFailedException $e) {
             throw new \RuntimeException("Cant't get certificates", 0, $e);
         }
 
@@ -90,7 +91,7 @@ class OpenSslService
 
         try {
             $execOutput = $this->runCommand($command);
-        } catch (\Exception $e) {
+        } catch (ProcessFailedException $e) {
             throw new \RuntimeException("Can't derive secret", 0, $e);
         }
 
@@ -102,18 +103,15 @@ class OpenSslService
     }
 
     /**
+     * @param string|array $command
      * @return string
-     * @throws \Exception
+     * @throws ProcessFailedException
      */
     private function runCommand($command)
     {
         $process = new Process($command);
-        $process->run();
+        $process->mustRun();
 
-        if ($process->isSuccessful()) {
-            return $process->getOutput();
-        }
-
-        throw new \Exception("Failed running openssl: {$process->getErrorOutput()}");
+        return $process->getOutput();
     }
 }

--- a/src/ApplePay/Decoding/OpenSSL/OpenSslService.php
+++ b/src/ApplePay/Decoding/OpenSSL/OpenSslService.php
@@ -99,7 +99,6 @@ class OpenSslService
      * @throws \RuntimeException
      */
     public function deriveKey($privateKeyFilePath, $publicKeyFilePath) {
-        // note: use base64 encoding for binary safe output
         $command = 'openssl pkeyutl -derive -inkey '.escapeshellarg($privateKeyFilePath).' -peerkey '.escapeshellarg($publicKeyFilePath);
 
         $descriptorspec = [


### PR DESCRIPTION
* Add `escapeshellarg()` just for defence-in-depth
* `proc_open` allows binary safe transfer of stdout
* No extra processes need to be spawned such as `tr` or `base64`. 
* No more output to stderr during tests 