### PR TITLE
Remove dependency phpseclib/phpseclib2_compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
         "php": "^7.4|^8.0",
         "ext-openssl": "*",
         "phpseclib/phpseclib": "^3.0",
-        "phpseclib/phpseclib2_compat": "^1.0",
         "spomky-labs/php-aes-gcm": "^1.2",
         "symfony/process": "^4.1|^5.0"
     },

--- a/src/ApplePay/ApplePayDecodingServiceFactory.php
+++ b/src/ApplePay/ApplePayDecodingServiceFactory.php
@@ -10,7 +10,6 @@ use PayU\ApplePay\Decoding\PKCS7SignatureValidator;
 use PayU\ApplePay\Decoding\PKCS7SignatureValidatorSettings;
 use PayU\ApplePay\Decoding\SignatureVerifier\SignatureVerifierFactory;
 use PayU\ApplePay\Decoding\TemporaryFile\TemporaryFileService;
-use phpseclib\File\ASN1;
 
 class ApplePayDecodingServiceFactory
 {
@@ -21,8 +20,7 @@ class ApplePayDecodingServiceFactory
     {
         $decoderFactory = new ApplePayDecoderFactory();
         $signatureVerifierFactory = new SignatureVerifierFactory();
-        $asn1 = new ASN1();
-        $asn1Wrapper = new Asn1Wrapper($asn1);
+        $asn1Wrapper = new Asn1Wrapper();
         $temporaryFileService = new TemporaryFileService();
         $openSslService = new OpenSslService();
         $pkcs7SignatureValidatorSettings = new PKCS7SignatureValidatorSettings();

--- a/src/ApplePay/Decoding/Asn1Wrapper.php
+++ b/src/ApplePay/Decoding/Asn1Wrapper.php
@@ -2,23 +2,15 @@
 
 namespace PayU\ApplePay\Decoding;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 class Asn1Wrapper
 {
     /** @var array */
     private $asn1;
 
-    /** @var ASN1 */
-    private $asn1Parser;
-
-    public function __construct(ASN1 $asn1)
-    {
-        $this->asn1Parser = $asn1;
-    }
-
     public function loadFromString($value) {
-        $this->asn1 = $this->asn1Parser->decodeBER($value);
+        $this->asn1 = ASN1::decodeBER($value);
     }
 
     public function getSignature() {
@@ -27,10 +19,7 @@ class Asn1Wrapper
 
     public function getSignedAttributes() {
         $signedAttributes = $this->asn1[0]['content'][1]['content'][0]['content'][4]['content'][0]['content'][3]; // ['content'];
-        $signedAttr = $this->asn1Parser->asn1map($signedAttributes, [
-            'type' => ASN1::TYPE_ANY,
-            'implicit' => true
-        ])->element;
+        $signedAttr = ASN1::asn1map($signedAttributes, ['type' => ASN1::TYPE_ANY, 'implicit' => true])->element;
         $signedAttr[0] = chr(0x31);
 
         return $signedAttr;
@@ -47,10 +36,7 @@ class Asn1Wrapper
                         ['content'][0] // cert_info tag
                         ['content'][6]; // key tag, all contents, including headers
 
-        $publicKey = $this->asn1Parser->asn1map($content, [
-            'type' => ASN1::TYPE_ANY,
-            'implicit' => true
-        ])->element;
+        $publicKey = ASN1::asn1map($content, ['type' => ASN1::TYPE_ANY, 'implicit' => true])->element;
 
         return trim($publicKey);
     }
@@ -60,11 +46,8 @@ class Asn1Wrapper
      */
     public function getSigningTime() {
         $timeAttribute = $this->asn1[0]['content'][1]['content'][0]['content'][4]['content'][0]['content'][3]['content'][1]['content'][1]['content'][0];
-        $signTime = $this->asn1Parser->asn1map($timeAttribute, [
-            'type' => ASN1::TYPE_UTC_TIME
-        ]);
 
-        return $signTime;
+        return ASN1::asn1map($timeAttribute, ['type' => ASN1::TYPE_UTC_TIME]);
     }
 
 }

--- a/src/ApplePay/Decoding/SignatureVerifier/SignatureVerifierFactory.php
+++ b/src/ApplePay/Decoding/SignatureVerifier/SignatureVerifierFactory.php
@@ -5,7 +5,6 @@ namespace PayU\ApplePay\Decoding\SignatureVerifier;
 use Exception;
 use PayU\ApplePay\Decoding\Asn1Wrapper;
 use PayU\ApplePay\Decoding\OpenSSL\OpenSslService;
-use phpseclib\File\ASN1;
 
 class SignatureVerifierFactory
 {
@@ -25,8 +24,7 @@ class SignatureVerifierFactory
     {
         switch ($version) {
             case self::ECC:
-                $asn1 = new ASN1();
-                $asn1Wrapper = new Asn1Wrapper($asn1);
+                $asn1Wrapper = new Asn1Wrapper();
                 $openSslService = new OpenSslService();
                 return new EccSignatureVerifier($asn1Wrapper, $openSslService);
             case self::RSA:

--- a/tests/Decoding/Asn1WrapperTest.php
+++ b/tests/Decoding/Asn1WrapperTest.php
@@ -2,7 +2,6 @@
 
 namespace PayU\ApplePay\Decoding;
 
-use phpseclib\File\ASN1;
 use PHPUnit\Framework\TestCase;
 
 class Asn1WrapperTest extends TestCase
@@ -17,8 +16,7 @@ class Asn1WrapperTest extends TestCase
 
     protected function setUp(): void
     {
-        $asn1 = new ASN1();
-        $this->asn1Wrapper = new Asn1Wrapper($asn1);
+        $this->asn1Wrapper = new Asn1Wrapper();
         $this->asn1Wrapper->loadFromString(base64_decode($this->certificateToTest));
     }
 


### PR DESCRIPTION
Use methods from phpseclib3, to allow removal of phpseclib/phpseclib2_compat dependency, to ensure security updates can be made.